### PR TITLE
feat(iceworks-cli): add migrate appworks cli message

### DIFF
--- a/packages/ice-npm-utils/CHANGELOG.md
+++ b/packages/ice-npm-utils/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.1.3
+
+- [feat] change cnpm registry to `registry.npmmirror.com`
+
 ## 2.1.2
 
 - [chore] remove `@iceworks/constant`, use `@appworks/constant`

--- a/packages/ice-npm-utils/package.json
+++ b/packages/ice-npm-utils/package.json
@@ -1,6 +1,7 @@
 {
   "name": "ice-npm-utils",
   "version": "2.1.2",
+  "tag": "release-2",
   "description": "npm utils for ice",
   "main": "lib/index.js",
   "files": [

--- a/packages/ice-npm-utils/package.json
+++ b/packages/ice-npm-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ice-npm-utils",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "tag": "release-2",
   "description": "npm utils for ice",
   "main": "lib/index.js",

--- a/packages/ice-npm-utils/src/__tests__/index.ts
+++ b/packages/ice-npm-utils/src/__tests__/index.ts
@@ -16,12 +16,9 @@ import {
   getAndExtractTarball,
 } from '../index';
 
-const defaultRegistry = 'https://registry.npm.taobao.org';
-// 也有可能返回这个源
-const cnpmResponseRegistry = 'https://registry.nlark.com' ;
-
-// 或者是这个源
-const npmMirrorRegistry = 'https://registry.npmmirror.com';
+const defaultRegistry = 'https://registry.npmmirror.com';
+// 预留 cnpm 返回多个源的可能性
+const registies = [defaultRegistry];
 
 jest.setTimeout(10 * 1000);
 
@@ -129,8 +126,7 @@ test('getNpmTarball', () => {
   return getNpmTarball('ice-npm-utils', '1.0.0').then((tarball) => {
     console.log('getNpmTarball ice-npm-utils', tarball);
     expect(
-      [defaultRegistry, cnpmResponseRegistry, npmMirrorRegistry]
-        .some(registry => tarball === `${registry}/ice-npm-utils/-/ice-npm-utils-1.0.0.tgz`)
+      registies.some(registry => tarball === `${registry}/ice-npm-utils/-/ice-npm-utils-1.0.0.tgz`)
     ).toBeTruthy();
   });
 });
@@ -139,8 +135,7 @@ test('getNpmTarball should get latest version', () => {
   return getNpmTarball('http').then((tarball) => {
     console.log('getNpmTarball http', tarball);
     expect(
-      [defaultRegistry, cnpmResponseRegistry, npmMirrorRegistry]
-        .some(registry => tarball === `${registry}/http/-/http-0.0.1-security.tgz`)
+      registies.some(registry => tarball === `${registry}/http/-/http-0.0.1-security.tgz`)
     ).toBeTruthy();
   });
 });

--- a/packages/ice-npm-utils/src/index.ts
+++ b/packages/ice-npm-utils/src/index.ts
@@ -157,7 +157,7 @@ function getLatestSemverVersion(baseVersion: string, versions: string[]): string
   versions = versions
     .filter((version) => semver.satisfies(version, `^${baseVersion}`))
     .sort((a, b) => {
-      return semver.gt(b, a);
+      return semver.gt(b, a) ? 1 : -1;
     });
   return versions[0];
 }
@@ -204,7 +204,7 @@ function getNpmRegistry(npmName = ''): string {
     return ALI_NPM_REGISTRY;
   }
 
-  return 'https://registry.npm.taobao.org';
+  return 'https://registry.npmmirror.com';
 }
 
 function getUnpkgHost(npmName = ''): string {

--- a/packages/iceworks-cli/CHANGELOG.md
+++ b/packages/iceworks-cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 3.4.9
+
+- [chore] 添加提示，建议用户迁移到 `@appworks/cli`
+
 ## 3.4.8
 
 - [chore] upgrade ice-npm-utils from 2.x to 3.x

--- a/packages/iceworks-cli/bin/iceworks.js
+++ b/packages/iceworks-cli/bin/iceworks.js
@@ -169,6 +169,19 @@ logCLIVersion();
 // check node version
 checkNodeVersion();
 
+// 提示用户迁移到 @appworks/cli
+console.log();
+console.log(
+  chalk.green(
+    'Iceworks 品牌已全面升级到 AppWorks，建议将物料开发工具迁移到 @appworks/cli，步骤：',
+  ),
+);
+console.log(chalk.green('1. 安装 AppWorks CLI: npm i -g @appworks/cli'));
+console.log(chalk.green('2. 移除 Iceworks CLI: npm rm -g iceworks'));
+console.log(chalk.green('3. 执行命令：appworks -V'));
+console.log(chalk.green('说明文档：https://appworks.site/materials/upgrade.html'));
+console.log();
+
 // check iceworks version
 checkIceworksVersion();
 

--- a/packages/iceworks-cli/package.json
+++ b/packages/iceworks-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iceworks",
-  "version": "3.4.9-0",
+  "version": "3.4.9",
   "description": "Iceworks CLI for develop project/material-collection/component.",
   "main": "bin/iceworks.js",
   "bin": {

--- a/packages/iceworks-cli/package.json
+++ b/packages/iceworks-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iceworks",
-  "version": "3.4.8",
+  "version": "3.4.9-0",
   "description": "Iceworks CLI for develop project/material-collection/component.",
   "main": "bin/iceworks.js",
   "bin": {

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -44,8 +44,8 @@ if (!branchName) {
 });
 
 async function publishPackage({ pkgDir, pkgData }) {
-  const { version, name } = pkgData;
-  const npmTag = branchName === 'master' ? 'latest' : 'beta';
+  const { version, name, tag } = pkgData;
+  const npmTag = tag || (branchName === 'stable/0.x' ? 'latest' : 'beta');
 
   const versionExist = await checkVersionExist(name, version, REGISTRY);
   if (versionExist) {
@@ -54,11 +54,11 @@ async function publishPackage({ pkgDir, pkgData }) {
   }
 
   const isProdVersion = /^\d+\.\d+\.\d+$/.test(version);
-  if (branchName === 'master' && !isProdVersion) {
+  if (branchName === 'stable/0.x' && !isProdVersion) {
     throw new Error(`禁止在 master 分支发布非正式版本 ${version}`);
   }
 
-  if (branchName !== 'master' && isProdVersion) {
+  if (branchName !== 'stable/0.x' && isProdVersion) {
     console.log(`非 master 分支 ${branchName}，不发布正式版本 ${version}`);
     return;
   }


### PR DESCRIPTION
- iceworks-cli 发布新版本，提示用户迁移到 `@appworks/cli`
- ice-npm-utils@2.x 修改 cnpm 默认的 registry，因为这个版本目前下载量还挺高的（最新的 3.x 版本已修改）